### PR TITLE
Allow 'date' class on datepicker input element

### DIFF
--- a/moment-datepicker/moment-datepicker.js
+++ b/moment-datepicker/moment-datepicker.js
@@ -32,7 +32,7 @@
 							    mousedown: $.proxy(this.mousedown, this)
 							});
         this.isInput = this.element.is('input');
-        this.component = this.element.is('.date') ? this.element.find('.add-on') : false;
+        this.component = !this.isInput && this.element.is('.date') ? this.element.find('.add-on') : false;
 
         if (this.isInput) {
             this.element.on({


### PR DESCRIPTION
The original code assumes that if the element has a 'date' class it must be a container that has an element with the 'add-on' class. In my case that causes problems because I apply the 'date' class to input elements, which cannot have an 'add-on' child. This change is intended to be non-breaking while allowing the date class to be applied to input elements.
