### PR TITLE
Added bower package definition

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,21 @@
+{
+  "name": "moment-datepicker",
+  "version": "1.0.0",
+  "main": ["./moment-datepicker/moment-datepicker.js", "./moment-datepicker/datepicker.css"],
+  "ignore": [
+    ".gitignore",
+    "Content",
+    "index.html",
+    "MomentDatepicker.csproj",
+    "MomentDatepicker.sln",
+    "nuget",
+    "packages",
+    "packages.config",
+    "Scripts",
+    "web.config"
+  ],
+  "dependencies": {
+    "jquery": ">= 1.9.0",
+    "moment": ">= 2.0.0"
+  }
+}


### PR DESCRIPTION
Hi, first of all, thank you for this component.
The content of this pull request is just the bower package definition; after merging this, you will be able to register the package doing: "bower register moment-datepicker your_git_repo_url" (see here http://bower.io/#registering-packages)
I think that you will also need to create the "1.0.0" tag manually if you decide to merge this in order for bower to work correctly.
Kind regards,
Germán.
