### PR TITLE
Fixed issue with a null date represented as today

### DIFF
--- a/moment-datepicker/moment-datepicker-ko.js
+++ b/moment-datepicker/moment-datepicker-ko.js
@@ -1,4 +1,4 @@
-(function ($, ko, moment) {
+(function ($, ko, moment, undefined) {
 
     //#region Utils
 


### PR DESCRIPTION
When no value is set, the value passed is `undefined`. However `moment(undefined)` has the same meaning as `moment()` which returns today's date. What we really want is `moment(null)` for null values. This can be checked by calling `isValid()` on the moment date, a null date should return false.

This prevents the binding handler from setting today's date by default.
