### PR TITLE
Allows use of an array of date formats

### DIFF
--- a/moment-datepicker/moment-datepicker.js
+++ b/moment-datepicker/moment-datepicker.js
@@ -477,7 +477,11 @@
         parseDate: function (value, format) {
             var mmnt = null;
             if (typeof value === "string") {
-                mmnt = moment(value, format, true);
+                if (Object.prototype.toString.call(format) === '[object Array]') {
+                    mmnt = moment(value, format, true);
+                } else {
+                    mmnt = moment(value, format);
+                }
             }
             if (!mmnt || !mmnt.isValid()) {
                 mmnt = moment(value);


### PR DESCRIPTION
Moment.js allows use of an array of date formats when parsing dates.

This means that you can do... `moment('05/05/1945', ['dd/mm/yyyy', 'dd-mm-yyy'])` and `moment('05-05-1945', ['dd/mm/yyyy', 'dd-mm-yyy'])` and both will work. Moment will keep trying the formats in the array until it finds the correct one to parse it with.

I have updated the date picker to accept an array for the 'format' parameter. It then uses the first format in the array as the display format.
