### PR TITLE
Issue #67 scrolling placement error solved

### DIFF
--- a/moment-datepicker/moment-datepicker.js
+++ b/moment-datepicker/moment-datepicker.js
@@ -209,12 +209,12 @@
 
             if (this.calendarPlacement == 'left') {
                 this.picker.css({
-                    top: offset.top + this.height + scrollTop - viewportOffset.top,
+                    top: offset.top + this.height,
                     left: offset.left + sourceItem[0].offsetWidth - this.picker[0].offsetWidth
                 });
             } else {
                 this.picker.css({
-                    top: offset.top + this.height + scrollTop - viewportOffset.top,
+                    top: offset.top + this.height,
                     left: offset.left,
                     zIndex : zIndex
                 });


### PR DESCRIPTION
This pull request soves a problem that happens when there is a scroll in the page. When this happens, the datepicker much more below than it should. 

The problem appears in the screenshot attached.

![screen shot 2016-03-16 at 18 28 55](https://cloud.githubusercontent.com/assets/9008887/13822344/85a29e20-eba5-11e5-91ab-eb04e7d105e1.png)
